### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -52,7 +52,7 @@ To use your Rainbowduino with mtXcontrol you have to upload the Firmware to your
 * multiple Device support including auto detection
 * Draw multicolor points, line and rows (4bit color support)
 * Add, delete, clear, fill, *copy &amp; paste*, move frames
-* *Draw letters and numbers*, Font configureable
+* *Draw letters and numbers*, Font configurable
 * Save to &amp; load from *Bitmap file*
 * Frame preview, easily navigate through
 * Keyboard shortcut for each function


### PR DESCRIPTION
@rngtng, I've corrected a typographical error in the documentation of the [mtXcontrol](https://github.com/rngtng/mtXcontrol) project. Specifically, I've changed configureable to configurable. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
